### PR TITLE
Fix batch replies

### DIFF
--- a/src/kraft_ws_jsonrpc.erl
+++ b/src/kraft_ws_jsonrpc.erl
@@ -61,7 +61,7 @@ handle_messages({batch, Messages}, State0) ->
         {[], State0},
         Unpacked
     ),
-    {[lists:flatten(Replies)], State3};
+    {lists:flatten(Replies), State3};
 handle_messages({single, Message}, State0) ->
     handle_message(unpack(Message), State0).
 


### PR DESCRIPTION
Hi Adam!
In my use case I was sending results in batch. Jsonrpc should not reply to results it expects.
The code as it is, is sending`{text, <<"[]">>}` when the reply list is empty.
Which is an invalid json message and should not be sent.