### PR TITLE
Fix dispatch overwrite

### DIFF
--- a/src/kraft_instance.erl
+++ b/src/kraft_instance.erl
@@ -37,12 +37,13 @@ init(#{app := App, owner := Owner, opts := #{port := Port} = Opts} = Params) ->
     InternalRoutes = {"/kraft", kraft_static, #{app => kraft}},
     AllRoutes = routes(App, [InternalRoutes | maps:get(routes, Params)]),
     Dispatch = cowboy_router:compile([{'_', lists:flatten(AllRoutes)}]),
-    persistent_term:put({kraft_dispatch, App}, Dispatch),
+    DispatchKey = {kraft_dispatch, App, make_ref()},
+    persistent_term:put(DispatchKey, Dispatch),
 
     % Start Cowboy
     ListenerName = listener_name(App),
     ProtocolOpts = #{
-        env => #{dispatch => {persistent_term, {kraft_dispatch, App}}},
+        env => #{dispatch => {persistent_term, DispatchKey}},
         stream_handlers => [
             kraft_fallback_h,
             cowboy_compress_h,


### PR DESCRIPTION
Bug appears when starting multiple listeners from the same application #8 

I'm doing this PR from a personal fork, since kraft went public I think we lost connection between our company private fork.  I cannot open a PR for the old private fork. I do not know if making it public would fix the situation.

We can alway re-fork after we switch dependency to this official repo.