### PR TITLE
Handle trap_exit message to avoid crash on shutdown

### DIFF
--- a/src/kraft_instance.erl
+++ b/src/kraft_instance.erl
@@ -43,8 +43,10 @@ handle_call(Request, From, _State) -> error({unknown_request, Request, From}).
 
 handle_cast(Request, _State) -> error({unknown_cast, Request}).
 
-% TODO: Handle owner/Cowboy crashes here
-handle_info(Info, _State) -> error({unknown_info, Info}).
+handle_info({'EXIT', _Pid, _Reason}, State) ->
+    {noreply, State};
+handle_info(Info, _State) ->
+    error({unknown_info, Info}).
 
 terminate(_Reason, Listeners) ->
     maps:foreach(


### PR DESCRIPTION
I noticed that this resulted in an ugly crash each time I redeploy on Fly.io.
Not sure what you should do here, but at least this avoids crashing.

```
init:stop().
ok
3> =ERROR REPORT==== 23-Aug-2023::15:37:01.955517 ===
** Generic server <0.1732.0> terminating 
** Last message in was {'EXIT',<0.1727.0>,normal}
** When Server state == #{#{port => 80,scheme => http} =>
                           #{listener =>
                              {kraft_listener,my_app,
                               #Ref<0.3893422842.2905079809.150506>},
                             persistent_terms =>
                              [{kraft_dispatch,my_app,
                                #Ref<0.3893422842.2905079809.150506>}]}}
** Reason for termination ==
** {{unknown_info,{'EXIT',<0.1727.0>,normal}},
    [{kraft_instance,handle_info,2,
                     [{file,"***"},
                      {line,47}]},
     {gen_server,try_dispatch,4,[{file,"gen_server.erl"},{line,1123}]},
     {gen_server,handle_msg,6,[{file,"gen_server.erl"},{line,1200}]},
     {proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,240}]}]}

```