### PR TITLE
Handle trap_exit message

### DIFF
--- a/src/kraft_instance.erl
+++ b/src/kraft_instance.erl
@@ -70,8 +70,10 @@ handle_call(Request, From, _State) -> error({unknown_request, Request, From}).
 
 handle_cast(Request, _State) -> error({unknown_cast, Request}).
 
-% TODO: Handler owner/Cowboy crashes here
-handle_info(Info, _State) -> error({unknown_info, Info}).
+handle_info({'EXIT', _Pid, _Reason}, State) ->
+    {noreply, State};
+handle_info(Info, _State) ->
+    error({unknown_info, Info}).
 
 terminate(_Reason, ListenerName) ->
     cowboy:stop_listener(ListenerName).


### PR DESCRIPTION
Leaving this message unhandled would cause a crash each time Cowboy is shut down causing bad app shutdowns which can break certain CT setups causing tests to fail.