### PR TITLE
Only forward text frames to callbacks

### DIFF
--- a/src/kraft_ws_util.erl
+++ b/src/kraft_ws_util.erl
@@ -1,5 +1,7 @@
 -module(kraft_ws_util).
 
+-include_lib("kernel/include/logger.hrl").
+
 % API
 -export([setup/4]).
 -export([callbacks/2]).
@@ -79,8 +81,16 @@ websocket_init(#{conn := Conn} = State0) ->
 
 websocket_handle(pong, #{ping := #{}} = State0) ->
     {[], State0};
+websocket_handle({text, _} = Frame, State0) ->
+    module(handle, [Frame], State0);
+websocket_handle(Frame, State0) when
+    element(1, Frame) =:= ping;
+    element(1, Frame) =:= pong
+->
+    {[], State0};
 websocket_handle(Frame, State0) ->
-    module(handle, [Frame], State0).
+    ?LOG_WARNING("Websocket unhandled frame: ~p", [Frame]),
+    {[], State0}.
 
 websocket_info('$kraft_ws_ping', State0) ->
     State1 = trigger_ping(State0),


### PR DESCRIPTION
- Ignore other websocket frames like ping, {ping, Data} ...

- Log when ignoring unexpected frames

Kraft websocket handlers `kraft_ws_jsonrpc` and `kraft_ws_json` only handle text frames. This led to function clause errors in our project where we used `kraft_ws_jsonrpc` and got `{ping, binary()}` frames in. This PR fixes it by only forwarding the text frames to the kraft websocket handler.