### PR TITLE
chore(config): set default format width

### DIFF
--- a/erlang_ls.config
+++ b/erlang_ls.config
@@ -9,3 +9,6 @@ include_dirs:
   - "_checkouts/*/include"
 code_path_extra_dirs:
   - "_build/default/lib/*/ebin"
+
+formatting:
+  width: 80


### PR DESCRIPTION
Sets the default line width for the code formatter to 80 characters in the `erlang_ls.config` file.chore(config): Add formatting width option