### PR TITLE
fix(kraft_rest): correctly generate 4XX responses

### DIFF
--- a/src/kraft_rest.erl
+++ b/src/kraft_rest.erl
@@ -21,15 +21,18 @@ exec(Conn0) ->
 handle(#{method := Method} = Conn0, Module, Route) ->
     Conn1 = kraft_conn:await_body(Conn0),
     Prefix = kraft_util:split_path(Route),
+    Function = method(Method),
     try
-        apply(Module, method(Method), [
+        apply(Module, Function, [
             prefix(maps:get(path, Conn1), Prefix), Conn1
         ])
     catch
         error:undef:StackTrace ->
-            return_error_code(undef, Module, Method, StackTrace, 405);
+            return_error_code(undef, Module, Function, StackTrace, 405);
         error:function_clause:StackTrace ->
-            return_error_code(function_clause, Module, Method, StackTrace, 404)
+            return_error_code(
+                function_clause, Module, Function, StackTrace, 404
+            )
     end.
 
 return_error_code(Type, Module, Method, StackTrace, Code) ->


### PR DESCRIPTION
Method was previously changed to a binary, so we need to match on the function name instead to determine 404 and 405 responses for the kraft_rest handler.