### PR TITLE
feat(error): Only render HTML errors for browsers

### DIFF
--- a/src/kraft_conn.erl
+++ b/src/kraft_conn.erl
@@ -11,6 +11,7 @@
 -export([response_body/1]).
 -export([response_body/2]).
 -export([respond/1]).
+-export([is_browser/1]).
 -export(['_meta'/1]).
 -export(['_meta'/2]).
 -export(['_set_meta'/3]).
@@ -115,6 +116,12 @@ respond(#{resp := Resp, adapter := {Module, Req0}} = Conn0) ->
             });
         _ ->
             error(status_code_not_set)
+    end.
+
+is_browser(#{headers := Headers}) ->
+    case maps:find(~"user-agent", Headers) of
+        {ok, <<"Mozilla/5.0", _/binary>>} -> true;
+        _ -> false
     end.
 
 -spec '_meta'(conn()) -> conn().

--- a/src/kraft_fallback_h.erl
+++ b/src/kraft_fallback_h.erl
@@ -43,7 +43,15 @@ insert_fallback(Command, _State) ->
 
 render(Code, #{req := Req}, Headers) ->
     Conn0 = kraft_conn:'_set_meta'(kraft_conn:new(Req, #{}), app, kraft),
-    Conn1 = kraft_template:response(Conn0, "error.html", context(Code, Conn0)),
+    Conn1 =
+        case kraft_conn:is_browser(Conn0) of
+            true ->
+                kraft_template:response(
+                    Conn0, "error.html", context(Code, Conn0)
+                );
+            false ->
+                Conn0
+        end,
     Body = kraft_conn:response_body(Conn1),
     Conn3 = kraft_conn:response_headers(Conn1, Headers#{
         <<"content-length">> => integer_to_binary(iolist_size(Body))


### PR DESCRIPTION
Avoid sending verbose HTML error pages, designed for browser inspection, to non-browser clients like curl or API consumers.

Introduces `kraft_conn:is_browser/1` to detect browser User-Agent strings and uses it in the default error handler and fallback handler to skip HTML template rendering for non-browser requests.

Also includes a minor visual improvement to stack traces on the HTML error page by marking the last call.